### PR TITLE
Mise à jour pour Livebox 4

### DIFF
--- a/core/class/livebox.class.php
+++ b/core/class/livebox.class.php
@@ -196,15 +196,15 @@ class livebox extends eqLogic {
 				$listpage = array("sysbus/NMC:reboot" => "");
 				break;
 			case "wpspushbutton":
-				$listpage = array("sysbus/NeMo/Intf/lan:setWLANConfig" => '"mibs":{"wlanvap":{"wl0":{"WPS":{"ConfigMethodsEnabled":"PushButton,Label,Ethernet"}}},"wl1":{"WPS":{"ConfigMethodsEnabled":"PushButton,Label,Ethernet"}}}', 
+				$listpage = array("sysbus/NeMo/Intf/lan:setWLANConfig" => '"mibs":{"wlanvap":{"wl0":{"WPS":{"ConfigMethodsEnabled":"PushButton,Label,Ethernet"}}},"eth6":{"WPS":{"ConfigMethodsEnabled":"PushButton,Label,Ethernet"}}}', 
 								"sysbus/NeMo/Intf/wl0/WPS:pushButton" => '',
-								"sysbus/NeMo/Intf/wl1/WPS:pushButton" => '');
+								"sysbus/NeMo/Intf/eth6/WPS:pushButton" => '');
 				break;
 			case "ring":
 				$listpage = array("sysbus/VoiceService/VoiceApplication:ring" => "");
 				break;
 			case "changewifi":
-				$listpage = array("sysbus/NeMo/Intf/lan:setWLANConfig" => '"mibs":{"penable":{"wifi'.$option[0].'_ath":{"PersistentEnable":'.$option[1].', "Enable":true}}}');
+				$listpage = array("sysbus/NeMo/Intf/lan:setWLANConfig" => '"mibs":{"penable":{"'.$option[0].'":{"PersistentEnable":'.$option[1].',"Enable":true}}}');
 				break;
 			case "devicelist":
 				$listpage = array("sysbus/Devices:get" => "");
@@ -254,7 +254,7 @@ class livebox extends eqLogic {
 		else
 		{
 			$json = json_decode($content, true);
-			if ( $json["status"] == "" )
+			if ( $json["status"] == "" && $page !== 'tv')
 			{
 				log::add('livebox','warning','Demande non traitee par la livebox. Param: ' .print_r($param,true));
 				return false;				
@@ -919,10 +919,10 @@ class livebox extends eqLogic {
 						$eqLogic_cmd->event($content["status"]["wlanvap"]["wl0"]["VAPStatus"]);
 					}
 					$eqLogic_cmd = $this->getCmd(null, 'wifi5status');
-					if ($eqLogic_cmd->execCmd() != $eqLogic_cmd->formatValue($content["status"]["wlanvap"]["wl1"]["VAPStatus"])) {
+					if ($eqLogic_cmd->execCmd() != $eqLogic_cmd->formatValue($content["status"]["wlanvap"]["eth6"]["VAPStatus"])) {
 						log::add('livebox','debug','Maj wifi5status');
 						$eqLogic_cmd->setCollectDate('');
-						$eqLogic_cmd->event($content["status"]["wlanvap"]["wl1"]["VAPStatus"]);
+						$eqLogic_cmd->event($content["status"]["wlanvap"]["eth6"]["VAPStatus"]);
 					}
 				}
 			}
@@ -983,21 +983,27 @@ class liveboxCmd extends cmd
 				$page = "wpspushbutton";
 				break;
 			case "wifi2.4on":
+				$option = array("wifi0_bcm", "true");
+				$page = "changewifi";
+				break;
 			case "wifion":
 				$option = array("0", "true");
 				$page = "changewifi";
 				break;
 			case "wifi2.4off":
+				$option = array("wifi0_bcm", "false");
+				$page = "changewifi";
+				break;
 			case "wifioff":
 				$option = array("0", "false");
 				$page = "changewifi";
 				break;
 			case "wifi5on":
-				$option = array("1", "true");
+				$option = array("wifi0_quan", "true");
 				$page = "changewifi";
 				break;
 			case "wifi5off":
-				$option = array("1", "false");
+				$option = array("wifi0_quan", "false");
 				$page = "changewifi";
 				break;
 		}

--- a/core/class/livebox.class.php
+++ b/core/class/livebox.class.php
@@ -79,7 +79,7 @@ class livebox extends eqLogic {
 				   'Content-Length: '.strlen($paramInternet)
 				   )
 				);
-				curl_setopt($session, CURLOPT_POSTFIELDS, $paramInternet); 
+				curl_setopt($session, CURLOPT_POSTFIELDS, $paramInternet);
 				curl_setopt($session, CURLOPT_URL, 'http://'.$this->getConfiguration('ip').'/ws');
 				curl_setopt($session, CURLOPT_RETURNTRANSFER, true);
 				curl_setopt($session, CURLOPT_COOKIESESSION, true);
@@ -137,7 +137,7 @@ class livebox extends eqLogic {
 			$cookie= fread($file, 100000000);
 			fclose($file);
 			unlink($cookiefile);
-			
+
 			$cookie1 = explode ("\t",$cookie);
 			$cookies = $cookie1[5].'='.$cookie1[6];
 			$this->_cookies = trim($cookies);
@@ -204,7 +204,7 @@ class livebox extends eqLogic {
 				} else {
 					$wifi5 = 'wl1';
 				}
-				$listpage = array("sysbus/NeMo/Intf/lan:setWLANConfig" => '"mibs":{"wlanvap":{"wl0":{"WPS":{"ConfigMethodsEnabled":"PushButton,Label,Ethernet"}}},"' . $wifi5 . '":{"WPS":{"ConfigMethodsEnabled":"PushButton,Label,Ethernet"}}}', 
+				$listpage = array("sysbus/NeMo/Intf/lan:setWLANConfig" => '"mibs":{"wlanvap":{"wl0":{"WPS":{"ConfigMethodsEnabled":"PushButton,Label,Ethernet"}}},"' . $wifi5 . '":{"WPS":{"ConfigMethodsEnabled":"PushButton,Label,Ethernet"}}}',
 								"sysbus/NeMo/Intf/wl0/WPS:pushButton" => '',
 								"sysbus/NeMo/Intf/$wifi5/WPS:pushButton" => '');
 				break;
@@ -219,7 +219,10 @@ class livebox extends eqLogic {
 				}
 				break;
 			case "changeguestwifi":
-				$listpage = array("sysbus/NMC.Guest:set" => '"Enable":'.$option['value']);
+				$listpage = array("sysbus/NMC/Guest:set" => '"Enable":'.$option['value']);
+				break;
+			case "guestwifistate":
+				$listpage = array("sysbus/NMC/Guest:get" => "");
 				break;
 			case "devicelist":
 				$listpage = array("sysbus/Devices:get" => "");
@@ -346,7 +349,7 @@ class livebox extends eqLogic {
 						$cmd->setSubType('numeric');
 						$cmd->setIsHistorized(0);
 						$cmd->setEventOnly(1);
-						$cmd->save();		
+						$cmd->save();
 					}
 
 					$cmd = $this->getCmd(null, 'debitdescendant');
@@ -360,7 +363,7 @@ class livebox extends eqLogic {
 						$cmd->setSubType('numeric');
 						$cmd->setIsHistorized(0);
 						$cmd->setEventOnly(1);
-						$cmd->save();		
+						$cmd->save();
 					}
 					$cmd = $this->getCmd(null, 'margebruitmontant');
 					if ( ! is_object($cmd)) {
@@ -373,7 +376,7 @@ class livebox extends eqLogic {
 						$cmd->setSubType('numeric');
 						$cmd->setIsHistorized(1);
 						$cmd->setEventOnly(1);
-						$cmd->save();		
+						$cmd->save();
 					}
 
 					$cmd = $this->getCmd(null, 'margebruitdescendant');
@@ -387,7 +390,7 @@ class livebox extends eqLogic {
 						$cmd->setSubType('numeric');
 						$cmd->setIsHistorized(0);
 						$cmd->setEventOnly(1);
-						$cmd->save();		
+						$cmd->save();
 					}
 					$cmd = $this->getCmd(null, 'lastchange');
 					if ( ! is_object($cmd)) {
@@ -400,7 +403,7 @@ class livebox extends eqLogic {
 						$cmd->setSubType('numeric');
 						$cmd->setIsHistorized(1);
 						$cmd->setEventOnly(1);
-						$cmd->save();		
+						$cmd->save();
 					}
 
 				}
@@ -408,34 +411,34 @@ class livebox extends eqLogic {
 					log::add('livebox','debug','Connexion mode ethernet');
 					$cmd = $this->getCmd(null, 'debitmontant');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 
 					$cmd = $this->getCmd(null, 'debitdescendant');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 
 					$cmd = $this->getCmd(null, 'margebruitmontant');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 
 					$cmd = $this->getCmd(null, 'margebruitdescendant');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 
 					$cmd = $this->getCmd(null, 'lastchange');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 
-				}			
+				}
 			}
 			$cmd = $this->getCmd(null, 'reset');
 			if ( is_object($cmd) ) {
-				$cmd->remove();		
+				$cmd->remove();
 			}
 			$content = $this->getPage("wifilist");
 			if ( $content !== false ) {
@@ -465,21 +468,21 @@ class livebox extends eqLogic {
 					}
 					$cmd = $this->getCmd(null, 'wifi2.4on');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 
 					$cmd = $this->getCmd(null, 'wifi2.4off');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 					$cmd = $this->getCmd(null, 'wifi5on');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 
 					$cmd = $this->getCmd(null, 'wifi5off');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 					$cmd = $this->getCmd(null, 'wifistatus');
 					if ( ! is_object($cmd)) {
@@ -492,16 +495,16 @@ class livebox extends eqLogic {
 						$cmd->setSubType('binary');
 						$cmd->setIsHistorized(0);
 						$cmd->setEventOnly(1);
-						$cmd->save();		
+						$cmd->save();
 					}
 					$cmd = $this->getCmd(null, 'wifi5status');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 
 					$cmd = $this->getCmd(null, 'wifi2.4status');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 				} elseif ( count($content["status"]) == 2 ) {
 					log::add('livebox','debug','Mode Wifi 2.4 et 5');
@@ -551,12 +554,12 @@ class livebox extends eqLogic {
 					}
 					$cmd = $this->getCmd(null, 'wifioff');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 
 					$cmd = $this->getCmd(null, 'wifion');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 					$cmd = $this->getCmd(null, 'wifi5status');
 					if ( ! is_object($cmd)) {
@@ -569,7 +572,7 @@ class livebox extends eqLogic {
 						$cmd->setSubType('binary');
 						$cmd->setIsHistorized(0);
 						$cmd->setEventOnly(1);
-						$cmd->save();		
+						$cmd->save();
 					}
 
 					$cmd = $this->getCmd(null, 'wifi2.4status');
@@ -583,11 +586,11 @@ class livebox extends eqLogic {
 						$cmd->setSubType('binary');
 						$cmd->setIsHistorized(0);
 						$cmd->setEventOnly(1);
-						$cmd->save();		
+						$cmd->save();
 					}
 					$cmd = $this->getCmd(null, 'wifistatus');
 					if ( is_object($cmd)) {
-						$cmd->remove();		
+						$cmd->remove();
 					}
 				}
 				$cmd = $this->getCmd(null, 'guestwifion');
@@ -612,15 +615,28 @@ class livebox extends eqLogic {
 					$cmd->setEventOnly(1);
 					$cmd->save();
 				}
+				$cmd = $this->getCmd(null, 'guestwifistatus');
+				if ( ! is_object($cmd)) {
+					$cmd = new liveboxCmd();
+					$cmd->setName('Etat Wifi Invité');
+					$cmd->setEqLogic_id($this->getId());
+					$cmd->setLogicalId('guestwifistatus');
+					$cmd->setUnite('');
+					$cmd->setType('info');
+					$cmd->setSubType('binary');
+					$cmd->setIsHistorized(0);
+					$cmd->setEventOnly(1);
+					$cmd->save();
+				}
 			}
 
 			$cmd = $this->getCmd(null, 'voipstatus');
 			if ( is_object($cmd)) {
-				$cmd->remove();		
+				$cmd->remove();
 			}
 			$cmd = $this->getCmd(null, 'numerotelephone');
 			if ( is_object($cmd)) {
-				$cmd->remove();		
+				$cmd->remove();
 			}
 			$content = $this->getPage("voip");
 			if ( $content !== false ) {
@@ -649,7 +665,7 @@ class livebox extends eqLogic {
 								$cmd->setIsHistorized(0);
 								$cmd->setEventOnly(1);
 								$cmd->setIsVisible(1);
-								$cmd->save();		
+								$cmd->save();
 							}
 							$cmd = $this->getCmd(null, 'numerotelephone'.$voip["signalingProtocol"]);
 							if ( ! is_object($cmd)) {
@@ -663,20 +679,20 @@ class livebox extends eqLogic {
 								$cmd->setIsHistorized(0);
 								$cmd->setEventOnly(1);
 								$cmd->setIsVisible(1);
-								$cmd->save();		
+								$cmd->save();
 							}
 						} else {
 							$cmd = $this->getCmd(null, 'voipstatus'.$voip["signalingProtocol"]);
 							if ( is_object($cmd)) {
-								$cmd->remove();		
+								$cmd->remove();
 							}
 							$cmd = $this->getCmd(null, 'numerotelephone'.$voip["signalingProtocol"]);
 							if ( is_object($cmd)) {
-								$cmd->remove();		
+								$cmd->remove();
 							}
 						}
 					} else {
-							log::add('livebox','debug','Mode VOIP '.$voip["signalingProtocol"].' inactif');							
+							log::add('livebox','debug','Mode VOIP '.$voip["signalingProtocol"].' inactif');
 						}
 					}
 				}
@@ -697,7 +713,7 @@ class livebox extends eqLogic {
 				$cmd->setSubType('string');
 				$cmd->setIsHistorized(0);
 				$cmd->setEventOnly(1);
-				$cmd->save();		
+				$cmd->save();
 			}
 			$cmd = $this->getCmd(null, 'reboot');
 			if ( ! is_object($cmd) ) {
@@ -745,7 +761,7 @@ class livebox extends eqLogic {
 				$cmd->setSubType('binary');
 				$cmd->setIsHistorized(0);
 				$cmd->setEventOnly(1);
-				$cmd->save();		
+				$cmd->save();
 			}
 
 			$cmd = $this->getCmd(null, 'linkstate');
@@ -759,7 +775,7 @@ class livebox extends eqLogic {
 				$cmd->setSubType('binary');
 				$cmd->setIsHistorized(0);
 				$cmd->setEventOnly(1);
-				$cmd->save();		
+				$cmd->save();
 			}
 
 			$cmd = $this->getCmd(null, 'connectionstate');
@@ -773,7 +789,7 @@ class livebox extends eqLogic {
 				$cmd->setSubType('binary');
 				$cmd->setIsHistorized(0);
 				$cmd->setEventOnly(1);
-				$cmd->save();		
+				$cmd->save();
 			}
 
 			$cmd = $this->getCmd(null, 'tvstatus');
@@ -787,7 +803,7 @@ class livebox extends eqLogic {
 				$cmd->setSubType('binary');
 				$cmd->setIsHistorized(0);
 				$cmd->setEventOnly(1);
-				$cmd->save();		
+				$cmd->save();
 			}
 
 			$cmd = $this->getCmd(null, 'ipwan');
@@ -801,7 +817,7 @@ class livebox extends eqLogic {
 				$cmd->setSubType('string');
 				$cmd->setIsHistorized(0);
 				$cmd->setEventOnly(1);
-				$cmd->save();		
+				$cmd->save();
 			}
 
 			$cmd = $this->getCmd(null, 'devicelist');
@@ -815,7 +831,7 @@ class livebox extends eqLogic {
 				$cmd->setSubType('string');
 				$cmd->setIsHistorized(0);
 				$cmd->setEventOnly(1);
-				$cmd->save();		
+				$cmd->save();
 			}
 
 			$cmd = $this->getCmd(null, 'ipv6wan');
@@ -829,7 +845,7 @@ class livebox extends eqLogic {
 				$cmd->setSubType('string');
 				$cmd->setIsHistorized(0);
 				$cmd->setEventOnly(1);
-				$cmd->save();		
+				$cmd->save();
 			}
 			$this->refreshInfo();
 			$this->logOut();
@@ -1001,12 +1017,22 @@ class livebox extends eqLogic {
 				$eqLogic_cmd->event(join(', ', $devicelist));
 			}
 		}
+		$content = $this->getPage("guestwifistate");
+		if ( $content !== false ) {
+			log::add('livebox','debug', 'Gest Wifi ' . print_r($content, true));
+			$eqLogic_cmd = $this->getCmd(null, 'guestwifistatus');
+			if ($eqLogic_cmd->execCmd() != $eqLogic_cmd->formatValue($content["status"]["Enable"])) {
+				log::add('livebox','debug','Maj wifi invité status');
+				$eqLogic_cmd->setCollectDate('');
+				$eqLogic_cmd->event($content["status"]["Enable"]);
+			}
+		}
 		$eqLogic_cmd = $this->getCmd(null, 'updatetime');
 		$eqLogic_cmd->event(date("d/m/Y H:i",(time())));
 	}
 }
 
-class liveboxCmd extends cmd 
+class liveboxCmd extends cmd
 {
 	/*	   * *************************Attributs****************************** */
 

--- a/desktop/js/livebox.js
+++ b/desktop/js/livebox.js
@@ -1,3 +1,26 @@
+function printEqLogicHelper(label,name,_eqLogic){
+	var trm = '<tr><td class="col-sm-3"><span style="font-size : 1em;">'+label+'</span></td><td><span class="label label-default" style="font-size : 1em;"> <span class="eqLogicAttr" data-l1key="configuration" data-l2key="'+name+'"></span></span></td></tr>';
+	
+	$('#table_infoseqlogic tbody').append(trm);
+	$('#table_infoseqlogic tbody tr:last').setValues(_eqLogic, '.eqLogicAttr');
+}
+
+// fonction executée par jeedom lors de l'affichage des details d'un eqlogic
+function printEqLogic(_eqLogic) {
+	if (!isset(_eqLogic)) {
+		var _eqLogic = {configuration: {}};
+	}
+	if (!isset(_eqLogic.configuration)) {
+		_eqLogic.configuration = {};
+	}
+	$('#table_infoseqlogic tbody').empty();
+    printEqLogicHelper("{{Fabricant}}","manufacturer",_eqLogic);
+    printEqLogicHelper("{{Type}}","productClass",_eqLogic);
+    printEqLogicHelper("{{Modèle}}","modelName",_eqLogic);
+    printEqLogicHelper("{{Numéro de série}}","serialNumber",_eqLogic);
+    printEqLogicHelper("{{Version hardware}}","hardwareVersion",_eqLogic);
+    printEqLogicHelper("{{Version software}}","softwareVersion",_eqLogic);
+}
 function addCmdToTable(_cmd) {
    if (!isset(_cmd)) {
         var _cmd = {configuration: {}};
@@ -25,15 +48,16 @@ function addCmdToTable(_cmd) {
 		tr += '<input type=hidden class="cmdAttr form-control input-sm" data-l1key="unite" value="">';
         tr += '</td>';
         tr += '<td>';
-		if (_cmd.logicalId == 'state' || _cmd.logicalId == 'tvstatus' || _cmd.logicalId == 'voipstatusH323' || _cmd.logicalId == 'voipstatusSIP' || _cmd.logicalId == 'connectionstate' || _cmd.logicalId == 'wifistatus' || _cmd.logicalId == 'wifi2.4status' || _cmd.logicalId == 'wifi5status' || _cmd.logicalId == 'linkstate' || _cmd.logicalId == 'debitmontant' || _cmd.logicalId == 'debitdescendant' || _cmd.logicalId == 'margebruitmontant' || _cmd.logicalId == 'margebruitdescendant') {
-			tr += '<span><input type="checkbox" class="cmdAttr" data-l1key="isHistorized"/> {{Historiser}}<br/></span>';
+        tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isVisible" checked/> {{Afficher}}</label></span>';
+		if (_cmd.subType == 'numeric' || _cmd.subType == 'binary') {
+			tr += '<span><label class="checkbox-inline"><input type="checkbox" class="cmdAttr checkbox-inline" data-l1key="isHistorized"/> {{Historiser}}</label></span>';
 		}
-        tr += '<span><input type="checkbox" class="cmdAttr" data-l1key="isVisible" checked/> {{Afficher}}<br/></span>';
         tr += '</td>';
 //		tr += '<td><i class="fas fa-minus-circle pull-right cmdAction cursor" data-action="remove"></i></td>';		
         tr += '<td>';
         if (is_numeric(_cmd.id)) {
             tr += '<a class="btn btn-default btn-xs cmdAction" data-action="configure"><i class="fas fa-cogs"></i></a> ';
+            tr += '<a class="btn btn-default btn-xs cmdAction" data-action="test"><i class="fa fa-rss"></i> {{Tester}}</a>';
         }
         tr += '</td>';
 		table_cmd = '#table_cmd';

--- a/desktop/php/livebox.php
+++ b/desktop/php/livebox.php
@@ -53,7 +53,9 @@ $eqLogics = eqLogic::byType('livebox');
  </ul>
  <div class="tab-content" style="height:calc(100% - 50px);overflow:auto;overflow-x: hidden;">
   <div role="tabpanel" class="tab-pane active" id="eqlogictabin">
-
+	<br/>
+		<div class="row">
+		<div class="col-sm-6">
         <form class="form-horizontal">
             <fieldset>
                 <legend>
@@ -120,18 +122,32 @@ $eqLogics = eqLogic::byType('livebox');
                 </div>
             </fieldset> 
         </form>
+        </div>
+        <div class="col-sm-6">
+            <form class="form-horizontal">
+                <fieldset>
+                    <table id="table_infoseqlogic" class="table table-condensed" style="border-radius: 10px;">
+                        <thead>
+                        </thead>
+                        <tbody>
+                        </tbody>
+                    </table>
+				</fieldset>
+			</form>
+		</div>
+  </div>
   </div>
   <div role="tabpanel" class="tab-pane" id="cmdtab">
 <br />
         <table id="table_cmd" class="table table-bordered table-condensed">
             <thead>
                 <tr>
-                    <th style="width: 50px;">#</th>
-                    <th>{{Nom}}</th>
+                    <th style="width: 100px;">#</th>
+                    <th style="width: 300px;">{{Nom}}</th>
 					<th style="width: 120px;">{{Icône-action}}</th>
                     <th style="width: 120px;">{{Sous-Type}}</th>
-                    <th style="width: 120px;">{{Paramètres}}</th>
-                    <th style="width: 100px;">{{Action}}</th>
+                    <th style="width: 120px;">{{Options}}</th>
+                    <th style="width: 100px;">{{Actions}}</th>
                 </tr>
             </thead>
             <tbody>

--- a/desktop/php/livebox.php
+++ b/desktop/php/livebox.php
@@ -47,8 +47,8 @@ $eqLogics = eqLogic::byType('livebox');
   <a class="btn btn-danger eqLogicAction pull-right" data-action="remove"><i class="fas fa-minus-circle"></i> {{Supprimer}}</a>
   <a class="btn btn-default eqLogicAction pull-right" data-action="configure"><i class="fas fa-cogs"></i> {{Configuration avancée}}</a>
   <ul class="nav nav-tabs" role="tablist">
-   <li role="presentation"><a class="eqLogicAction cursor" aria-controls="home" role="tab" data-action="returnToThumbnailDisplay"><i class="fas fa-arrow-circle-left"></i></a></li>
-   <li role="presentation" class="active"><a href="#eqlogictabin" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-tachometer-alt"></i> {{LiveBox}}</a></li>
+   <li role="presentation"><a href="" class="eqLogicAction" aria-controls="home" role="tab" data-toggle="tab" data-action="returnToThumbnailDisplay"><i class="fas fa-arrow-circle-left"></i></a></li>
+   <li role="presentation" class="active"><a href="#eqlogictabin" aria-controls="home" role="tab" data-toggle="tab"><i class="fas fa-tachometer-alt"></i> {{Equipement}}</a></li>
    <li role="presentation"><a href="#cmdtab" aria-controls="profile" role="tab" data-toggle="tab"><i class="fas fa-list-alt"></i> {{Commandes}}</a></li>
  </ul>
  <div class="tab-content" style="height:calc(100% - 50px);overflow:auto;overflow-x: hidden;">

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -1,11 +1,9 @@
 
-WARNING: Detail complet des mises à jour sur https://github.com/guenneguezt/plugin-livebox/commits/master[Historique Commit]
+# WARNING:
 
-Liste des évolutions majeures de la version courante :
+Detail complet des mises à jour sur https://github.com/jeedom/plugin-livebox/commits/master
 
-- Correction de problème de compte
-
-Anciennes évolutions :
+# Anciennes évolutions :
 
 - Correction lors de la sauvegarde de la livebox
 - Modification pour compatibilité Jeedom V3
@@ -28,3 +26,10 @@ Anciennes évolutions :
 - Optimisation pour ne pas mettre à jour les données si elle le sont déjà.
 - Suppression de commande reset
 - Première version bêta
+- Correction de problème de compte
+
+# Version du 07/12/2019
+
+- Correction des commandes Wifi pour la Livebox 4
+- Ajout des commandes pour le Wifi invité
+- Ajout des caractéristiques de la box dans la page équipement


### PR DESCRIPTION
Bonjour Alex,
J'ai réparé les commandes pour activer/désactiver les Wifis 2.4 GHz et 5 GHz qui ne marchaient pas sur la Livebox 4, je pense que çà marche aussi pour la Livebox 5 mais je ne peux pas tester faute de matériel.
J'ai aussi ajouté des commandes pour le Wifi invité.
J'ai mis à jour le changelog mais pas encore la doc qui aurait besoin d'un petit lifting après son passage en md.
Un truc me chiffonne : c'est normal qu'il y ait à la fois un dossier doc et un dossier docs ou c'est moi qui ai fait une bétise ? Dis moi s'il faut en supprimer un des deux et je ferai un PR.